### PR TITLE
Updated symfony/var-dumper version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 /vendor
 composer.lock
 *.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "symfony/var-dumper": "~3.3|~4.0|~5.0|~6.0"
+        "symfony/var-dumper": "~3.3|~4.0|~5.0|~6.0|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0|~7.0|~8.0|~9.0",


### PR DESCRIPTION
This pull request updates the `symfony/var-dumper` dependency in composer.json to include version 7.0. This change is necessary to ensure compatibility with the [pragmarx/countries-laravel](https://packagist.org/packages/pragmarx/) package when upgrading to Laravel 11